### PR TITLE
dev: fix lesson number

### DIFF
--- a/lessons/02-smart_contracts/lesson.md
+++ b/lessons/02-smart_contracts/lesson.md
@@ -1,4 +1,4 @@
-# Lesson 03: Smart Contracts
+# Lesson 02: Smart Contracts
 
 ## Goal
 
@@ -55,4 +55,3 @@ In the future, we plan to create a MetaMask snap as well as other tools based on
    ```bash
    nil_cli -c ./config.ini contract call-readonly <contract address> getValue --abi ./artifacts/Incrementer.abi
    ```
-

--- a/lessons/03-cross_shard_communication/lesson.md
+++ b/lessons/03-cross_shard_communication/lesson.md
@@ -1,4 +1,4 @@
-# Lesson 04: Cross-Shard Communication
+# Lesson 03: Cross-Shard Communication
 
 ## Goal
 
@@ -42,7 +42,7 @@ This function is used for sending cross-shard messages.
 
    Once added, we can deploy the contract as usual:
    ```bash
-   npx hardhat ignition deploy ./ignition/modules/Caller.ts --network nil  
+   npx hardhat ignition deploy ./ignition/modules/Caller.ts --network nil
    ```
    We should return shardId to default:
    ```bash
@@ -54,7 +54,7 @@ This function is used for sending cross-shard messages.
 
    To verify that the contract is deployed, we can check the contract code using the CLI:
    ```bash
-   nil_cli -c ./config.ini contract code <caller address> 
+   nil_cli -c ./config.ini contract code <caller address>
    ```
 
 3. **Trigger the Call Method from the Caller Contract**
@@ -70,4 +70,3 @@ This function is used for sending cross-shard messages.
    ```bash
    nil_cli -c ./config.ini contract call-readonly <Incrementer address> getValue --abi ./Incrementer.abi
    ```
-

--- a/lessons/04-multi_currency/lesson.md
+++ b/lessons/04-multi_currency/lesson.md
@@ -1,4 +1,4 @@
-# Lesson 05: Multi-Currency
+# Lesson 04: Multi-Currency
 
 ## Goal
 
@@ -59,4 +59,3 @@ The network also has a multi-currency mechanism. All accounts (smart contracts) 
    ```bash
    nil_cli -c ./config.ini wallet send-tokens <Destination contract address> <native currency> --token <id>=value
    ```
-

--- a/lessons/05-messages/lesson.md
+++ b/lessons/05-messages/lesson.md
@@ -1,4 +1,4 @@
-# Lesson 02: Messages
+# Lesson 05: Messages
 
 ## Goal
 
@@ -79,8 +79,8 @@ The contract receiving an external message must implement an additional function
 
 ```solidity
 function verifyExternal(
-        uint256 messageHash, 
-        bytes calldata authData 
+        uint256 messageHash,
+        bytes calldata authData
     ) external view returns (bool)
 ```
 


### PR DESCRIPTION
The lesson number on the folder level doesn't matches with the version number on the `.md` lessons, this PR fixes it.