### PR TITLE
fix .env.example

### DIFF
--- a/hardhat/.env.example
+++ b/hardhat/.env.example
@@ -2,13 +2,13 @@
 
 # Specify the RPC endpoint of your cluster
 # For example, if your cluster's RPC endpoint is at "http://127.0.0.1:8529", set it as below
-NIL_RPC_ENDPOINT: "http://127.0.0.1:8529"
+NIL_RPC_ENDPOINT = "http://127.0.0.1:8529"
 
 # Specify the private key used for signing transactions
 # This should be a hexadecimal string corresponding to your account's private key
-PRIVATE_KEY: "41285f03e8692676bf80a98e4052a008026427a7302ca97cb06edcd60689850b"
+PRIVATE_KEY = "41285f03e8692676bf80a98e4052a008026427a7302ca97cb06edcd60689850b"
 
 # Specify the wallet address associated with your private key
 # Wallets can be created using the =nil; CLI
 # This address will be used for transactions on the =nil; network
-WALLET_ADDR: "0x0001f1494b9938E6Fd519441562B2B451eb94fD2"
+WALLET_ADDR = "0x0001f1494b9938E6Fd519441562B2B451eb94fD2"

--- a/hardhat/.env.example
+++ b/hardhat/.env.example
@@ -11,4 +11,4 @@ PRIVATE_KEY: "41285f03e8692676bf80a98e4052a008026427a7302ca97cb06edcd60689850b"
 # Specify the wallet address associated with your private key
 # Wallets can be created using the =nil; CLI
 # This address will be used for transactions on the =nil; network
-NIL_WALLET_ADDR="0x0001f1494b9938E6Fd519441562B2B451eb94fD2"
+WALLET_ADDR: "0x0001f1494b9938E6Fd519441562B2B451eb94fD2"


### PR DESCRIPTION
cloes #9 

This PR fixes the `.env.example` by using the correct environment variable name, which is accepted in the hardhat config file, and makes the format of declaring environment variables uniform.