### PR TITLE
Changed README.md to the right network parameter

### DIFF
--- a/hardhat/.env.example
+++ b/hardhat/.env.example
@@ -2,13 +2,13 @@
 
 # Specify the RPC endpoint of your cluster
 # For example, if your cluster's RPC endpoint is at "http://127.0.0.1:8529", set it as below
-NIL_RPC_ENDPOINT: "http://127.0.0.1:8529"
+NIL_RPC_ENDPOINT=http://127.0.0.1:8529
 
 # Specify the private key used for signing transactions
 # This should be a hexadecimal string corresponding to your account's private key
-PRIVATE_KEY: "41285f03e8692676bf80a98e4052a008026427a7302ca97cb06edcd60689850b"
+PRIVATE_KEY=397d8c9b34b10f28be32dd524f8614f557842f6f3d9783d310a6a6459a809bef
 
 # Specify the wallet address associated with your private key
 # Wallets can be created using the =nil; CLI
 # This address will be used for transactions on the =nil; network
-NIL_WALLET_ADDR="0x0001f1494b9938E6Fd519441562B2B451eb94fD2"
+NIL_WALLET_ADDR=0x0001d0C54F86d25B4D5248c2243CBBF0727eE924

--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -43,7 +43,7 @@ To deploy and interact with the Incrementer contract, use the following commands
 npx hardhat ignition deploy ./ignition/modules/Incrementer.ts --network nil_cluster
 
 # Interact with the contract
-npx hardhat increment --network nil_cluster --contract <Contract Address>
+npx hardhat increment --network nil --contract <Contract Address>
 ```
 
 ## 💪 Contributing


### PR DESCRIPTION
The command in the readme doesn't match the right keyword used in config. We are using `nil_cluster` in readme and `nil` in config which would throw and `Network doesn't exist error`. This is a PR fixing that.